### PR TITLE
warp torch tensors with homography in c++/cuda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
-# torch_cuda_warper
-A custom warper for torch tensors based on CUDA Kernel acceleration
+# Torch cuda warper
+A simple Cuda Kernel to warp torch tensors using an homogrpahy
+- Cuda version
+- CPU version fallback (not optimized)
+Seems like the custom cuda version is much faster that the native torch combination of `torch.nn.functional.affine_grid` & `torch.nn.functional.grid_sample`.
+
+
+
+This code sample was initiated during a discussion on  [Pytorch github discussion](https://github.com/pytorch/pytorch/issues/104296).
+
+
+## Important notes
+This draft is far less generic than what pytorch provides regarding the warping feature.
+- **Tensor format**:
+    - Supports channel first NCHW tensors only.
+    - 2D images only, no 3D grid warps.
+- **Interpolation mode**:
+    - Bilinear interpolation only
+    - no nearest neighbor, no bicubic.
+- **No backward operator supported**
+
+
+# Compile
+Compile as a python library. Requires the right Cuda / Torch compiling environment, follow the Torch C++ / Cuda extention [tutorial](https://pytorch.org/tutorials/advanced/cpp_extension.html) for more info.
+
+`cd torch_cuda_warper`
+
+`python3 setup.py install --user`
+
+## Test
+
+```
+pytest-3 test_warp.py
+```
+
+## Bench
+```
+python3 test_warp.py
+```
+Using **pytorch 2.1.0.dev20230711+cu121** on a  **NVIDIA Geforce RTX2060**
+```
+Warp forward custom cuda kernel 0.0027 s, bandwidth 446GB/s
+Warp forward torch 0.0110 s, bandwidth 109GB/s
+Speed up 4.0x
+```
+
+-----------------------------------------------------
+
+Using **pytorch 1.11.0+cu113** on a **Nvidia A100 & RTX3090**.
+Nvidia A100 80GB PCIe
+
+```
+Warp forward custom cuda kernel 0.0004 s, bandwidth 3158GB/s
+Warp forward torch 0.0030 s, bandwidth 403GB/s
+Speed up 7.7x
+```
+
+Nvidia RTX3090
+```
+Warp forward custom cuda kernel 0.0011 s, bandwidth 1065GB/s
+Warp forward torch 0.0047 s, bandwidth 254GB/s
+Speed up 4.1x
+```
+

--- a/include/warp.hpp
+++ b/include/warp.hpp
@@ -1,0 +1,4 @@
+/**
+ * @brief Conventional Torch channels-first (NCHW) tensor layout
+ */
+enum NCHWTensorLayout { BATCH_DIM = 0, CHANNELS_DIM = 1, HEIGHT_DIM = 2, WIDTH_DIM = 3, NUM_DIMS = 4 };

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+import os
+
+from setuptools import setup
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+
+setup(name='torch_warper',
+      ext_modules=[
+          CUDAExtension('torch_warper', ['src/warp.cpp', 'src/warping.cu'],
+                        include_dirs=[os.path.join(base_dir, 'include')],
+                        extra_compile_args={
+                            'cxx': ['-Wfatal-errors', '-O3', '-std=c++17'],
+                            'nvcc': ['-O3', '-Xptxas', '-O3,-v']
+                        }),
+      ],
+      cmdclass={'build_ext': BuildExtension})

--- a/src/warp.cpp
+++ b/src/warp.cpp
@@ -1,0 +1,99 @@
+#include "warp.hpp"
+
+#include <pybind11/numpy.h>
+#include <torch/extension.h>
+#include <cstdint>
+#include <fstream>
+#include <tuple>
+#include <vector>
+
+// -------- CUDA forward declarations
+void launchWarpKernel(const torch::Tensor& image, const torch::Tensor& homography, torch::Tensor& warped);
+
+// -------- C++ interface
+
+/**
+ * @brief Applies an homograpphy to a batch of 2D images
+ *
+ * @param image     batch of images to process, a NCHW tensor, C is the nimber of channels / colors, N is the batch dimension
+ * @param homography the homography 3x3 to apply, a N,3,3 tensor - Convention: indirect order
+ */
+torch::Tensor warpImage(torch::Tensor& image,
+                        const torch::Tensor& homography,
+                        const std::optional<int> width,
+                        const std::optional<int> height) {
+    // ensure equal batch size between image and homography
+    AT_ASSERTM(image.size(BATCH_DIM) == homography.size(BATCH_DIM),
+               "Expecting the image and the homography to have the same batch size N.");
+    // check image shape and layout
+    AT_ASSERTM(image.dim() == NUM_DIMS, "Expecting a 4-dimensional image tensor");
+    AT_ASSERTM(homography.dim() == 3, "Expecting a 3-dimensional homography tensor");
+    AT_ASSERTM(homography.size(1) == 3, "Expecting a N,3,3 tensor");
+    AT_ASSERTM(homography.size(2) == 3, "Expecting a N,3,3 tensor");
+
+    torch::Tensor out_image;
+    if (width && height) {
+        out_image = torch::zeros({image.size(BATCH_DIM), image.size(CHANNELS_DIM), height.value(), width.value()},
+                                image.options());
+    } else {
+        out_image = torch::zeros_like(image);
+    }
+    if (image.is_cuda()) {
+        AT_ASSERTM(image.is_cuda(), "Expecting the image tensor to be stored in GPU memory");
+        AT_ASSERTM(homography.is_cuda(), "Expecting the homography tensor to be stored in GPU memory");
+        launchWarpKernel(image, homography, out_image);
+    } else {
+        AT_ASSERTM(!homography.is_cuda(), "Expecting the homography tensor to be stored in CPU memory");
+        // CPU ACCESSORS
+        // https://pytorch.org/cppdocs/notes/tensor_basics.html#cpu-accessors
+        // @TODO: parallel for implementation
+        auto out = out_image.accessor<float, NUM_DIMS>();
+        auto img = image.accessor<float, NUM_DIMS>();
+        auto homog = homography.accessor<float, 3>();
+        for (int n = 0; n < out_image.size(BATCH_DIM); n++) {
+            for (int y = 0; y < out_image.size(HEIGHT_DIM); y++) {
+                for (int x = 0; x < out_image.size(WIDTH_DIM); x++) {
+                    auto x_coord = homog[n][0][0] * x + homog[n][0][1] * y + homog[n][0][2];
+                    auto y_coord = homog[n][1][0] * x + homog[n][1][1] * y + homog[n][1][2];
+                    auto z_coord = homog[n][2][0] * x + homog[n][2][1] * y + homog[n][2][2];
+                    x_coord /= z_coord;
+                    y_coord /= z_coord;
+
+                    // BILINEAR INTERPOLATION IMPLEMENTATION
+                    int64_t x_coord_floor = floor(x_coord);
+                    int64_t y_coord_floor = floor(y_coord);
+                    auto res_x = x_coord - x_coord_floor;
+                    auto res_y = y_coord - y_coord_floor;
+                    if (x_coord_floor >= 0 and x_coord_floor < image.size(WIDTH_DIM) - 1 and y_coord_floor >= 0 and
+                        y_coord_floor < image.size(HEIGHT_DIM) - 1) {
+                        for (int c = 0; c < img.size(1); c++) {
+                            auto top_left = img[n][c][y_coord_floor][x_coord_floor];
+                            auto top_right = img[n][c][y_coord_floor][x_coord_floor + 1];
+                            auto bottom_left = img[n][c][y_coord_floor + 1][x_coord_floor];
+                            auto bottom_right = img[n][c][y_coord_floor + 1][x_coord_floor + 1];
+                            auto top_interp = res_x * top_right + (1.f - res_x) * top_left;
+                            auto bottom_interp = res_x * bottom_right + (1.f - res_x) * bottom_left;
+                            out[n][c][y][x] = res_y * bottom_interp + (1.f - res_y) * top_interp;
+                        }
+                    } else {
+                        for (int c = 0; c < img.size(CHANNELS_DIM); c++) {
+                            out[n][c][y][x] = 0.f;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return out_image;
+};
+
+// -------- pybind11 module definition
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
+    module.def("warp_image",
+               &warpImage,
+               py::arg("image"),
+               py::arg("homography"),
+               py::arg("width") = py::none(),
+               py::arg("height") = py::none(), "Applies a warp to an image based on a homography");
+}

--- a/src/warping.cu
+++ b/src/warping.cu
@@ -1,0 +1,73 @@
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/extension.h>
+#include "warp.hpp"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+template <typename T>
+__device__ inline T sqr(T x) {
+    return x * x;
+}
+
+namespace kernels {
+template <typename scalar_t, const int N_CHANNELS>
+__global__ void applyWarpKernel(torch::PackedTensorAccessor32<scalar_t, 4, torch::RestrictPtrTraits> img,
+                                torch::PackedTensorAccessor32<scalar_t, 3, torch::RestrictPtrTraits> homog,
+                                torch::PackedTensorAccessor32<scalar_t, 4, torch::RestrictPtrTraits> warped) {
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iy = blockIdx.y * blockDim.y + threadIdx.y;
+    int n = blockIdx.z;
+    auto x_coord = homog[n][0][0] * ix + homog[n][0][1] * iy + homog[n][0][2];
+    auto y_coord = homog[n][1][0] * ix + homog[n][1][1] * iy + homog[n][1][2];
+    auto z_coord = homog[n][2][0] * ix + homog[n][2][1] * iy + homog[n][2][2];
+    x_coord /= z_coord;
+    y_coord /= z_coord;
+    int64_t x_coord_floor = floor(x_coord);
+    int64_t y_coord_floor = floor(y_coord);
+    auto res_x = x_coord - x_coord_floor;
+    auto res_y = y_coord - y_coord_floor;
+    if (iy < warped.size(HEIGHT_DIM) and ix < warped.size(WIDTH_DIM)) {
+        if (x_coord_floor >= 0 and x_coord_floor < img.size(WIDTH_DIM) - 1 and y_coord_floor >= 0 and
+            y_coord_floor < img.size(HEIGHT_DIM) - 1) {
+            for (int c = 0; c < N_CHANNELS; ++c) {
+                auto top_left = img[n][c][y_coord_floor][x_coord_floor];
+                auto top_right = img[n][c][y_coord_floor][x_coord_floor + 1];
+                auto bottom_left = img[n][c][y_coord_floor + 1][x_coord_floor];
+                auto bottom_right = img[n][c][y_coord_floor + 1][x_coord_floor + 1];
+                auto top_interp = res_x * top_right + (1.f - res_x) * top_left;
+                auto bottom_interp = res_x * bottom_right + (1.f - res_x) * bottom_left;
+                warped[n][c][iy][ix] = res_y * bottom_interp + (1.f - res_y) * top_interp;
+            }
+        } else {
+            for (int c = 0; c < N_CHANNELS; ++c) {
+                warped[n][c][iy][ix] = 0.f;
+            }
+        }
+    }
+}
+
+} // namespace kernels
+
+void launchWarpKernel(const torch::Tensor& image, const torch::Tensor& homography, torch::Tensor& warped) {
+    // get CUDA stream
+    const auto deviceIndex = image.device().index();
+    auto stream = c10::cuda::getCurrentCUDAStream(deviceIndex);
+
+    // setup thread grid
+    // @TODO:kind of default
+    static const dim3 threads(32, 32, 1);
+    const dim3 blocks((warped.size(WIDTH_DIM) + threads.x - 1) / threads.x,
+                      (warped.size(HEIGHT_DIM) + threads.y - 1) / threads.y,
+                      warped.size(BATCH_DIM));
+
+    AT_DISPATCH_FLOATING_TYPES(image.type(), "warping", [&] {
+        auto imagePtr = image.packed_accessor32<scalar_t, 4, torch::RestrictPtrTraits>();
+        auto outPtr = warped.packed_accessor32<scalar_t, 4, torch::RestrictPtrTraits>();
+        auto homographyPtr = homography.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>();
+        kernels::applyWarpKernel<scalar_t, 3><<<blocks, threads, 0, stream.stream()>>>(imagePtr, homographyPtr, outPtr);
+    });
+
+    // check error
+    C10_CUDA_CHECK(cudaGetLastError());
+}

--- a/test_warp.py
+++ b/test_warp.py
@@ -1,0 +1,97 @@
+import pytest
+from torch.utils.benchmark import Timer
+import logging
+import torch
+from warper_utils import transform_metric_to_normalized_torch
+try:
+    import torch_warper
+except:
+    torch_warper = None
+    logging.warning("Need to build the torch C++/Cuda kernel first")
+current_device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def device_fixture():
+    current_device = torch.device("cuda", 0)
+    torch.cuda.set_device(current_device)
+
+
+@torch.jit.script
+def torch_homography(img: torch.Tensor, homography: torch.Tensor, align_corners: bool = True):
+    """Apply homography transformation using torch operators
+
+    Parameters
+    ----------
+    x : input tensor in NCHW
+    homography : tensor N33 with the homography transformation
+    """
+    with torch.no_grad():
+        grid = torch.nn.functional.affine_grid(homography[:, :2, :], img.shape, align_corners=align_corners)
+        yt = torch.nn.functional.grid_sample(img, grid, mode="bilinear", align_corners=align_corners)
+    return yt, grid
+
+
+@pytest.mark.parametrize("spatial_size", [64])
+@pytest.mark.parametrize("rot_angle", [0, 30, 45, 60, 90])
+def test_warp_forward(spatial_size, rot_angle):
+    n, ch = 1, 3  # batch and channels
+    img = torch.eye(spatial_size, dtype=torch.float32).repeat(n, ch, 1, 1).to(current_device)  # NCHW
+    phi = torch.tensor([rot_angle * 3.1415 / 180])
+    s = torch.sin(phi)
+    c = torch.cos(phi)
+    homography = torch.tensor([[c, -s, 0.], [s, c, 0.], [0., 0., 1.]]).repeat(n, 1, 1).to(current_device)
+    yp = torch_warper.warp_image(img, homography)
+    yp_cpu = torch_warper.warp_image(img.cpu(), homography.cpu())
+    assert torch.allclose(yp.cpu(), yp_cpu, rtol=1.e-4)
+    homography_pytorch = transform_metric_to_normalized_torch(homography.double(),
+                                                              img.shape[-2:],
+                                                              img.shape[-2:],
+                                                              is_affinity=False).to(current_device).float()
+    yt, _grid = torch_homography(img, homography_pytorch, align_corners=True)
+    assert torch.allclose(yp, yt, rtol=1., atol=1.e-6)
+
+
+def time_forward(x, homography, torch_ref=False):
+    stmt = "torch_homography(x, homography)" if torch_ref else "torch_warper.warp_image(x, homography)"
+    t = Timer(stmt=stmt,
+              globals={
+                  "x": x,
+                  "homography": homography,
+                  "torch_homography": torch_homography,
+                  "torch_warper": torch_warper
+              })
+    res = t.blocked_autorange(min_run_time=1.)
+    timec = res.median
+    return timec
+
+
+def warp_perf(spatial_size):
+    n, ch = 16, 32  # batch and channels
+    data_size = 4
+    nbytes_read_write = data_size * (3 * 3 * n + 2 * ch * n
+                                     )  # read homography matrix + read and write (2*) one float per channel per batch
+    nbytes_read_write_torch = data_size * (2 * 3 * n + 2 * n + 2 * n * ch
+                                           )  # read affine + write grid + read and write warp
+    img = torch.eye(spatial_size, dtype=torch.float32).repeat(n, ch, 1, 1).to(current_device)
+    phi = torch.rand(n) * 3.141592
+    s, c = torch.sin(phi), torch.cos(phi)
+    r1 = torch.stack([c, -s, torch.zeros(n)], 1)
+    r2 = torch.stack([s, c, torch.zeros(n)], 1)
+    r3 = torch.stack([torch.zeros(n), torch.zeros(n), torch.ones(n)], 1)
+    homography = torch.stack([r1, r2, r3], 1).to(current_device)
+    timec = time_forward(img, homography)
+    print(
+        f"Warp forward custom cuda kernel {timec:.4f} s, bandwidth {spatial_size**2*nbytes_read_write*1e-9/timec:.4f}GB/s"
+    )
+    homography = transform_metric_to_normalized_torch(homography.double(), img.shape[-2:], img.shape[-2:],
+                                                      is_affinity=False).to(current_device).float()
+    timec_ref = time_forward(img, homography, torch_ref=True)
+    print(
+        f"Warp forward torch {timec_ref:.4f} s, bandwidth {spatial_size**2*nbytes_read_write_torch*1e-9/timec_ref:.4f}GB/s"
+    )
+    print(f"Speed up {timec_ref/timec:.1f}x")
+
+
+if __name__ == "__main__":
+    warp_perf(512)

--- a/warper_utils.py
+++ b/warper_utils.py
@@ -1,0 +1,47 @@
+import torch
+
+
+def normalized_to_metric(h: int, w: int, dtype=torch.float64, device='cpu') -> torch.Tensor:
+    """Referential change 3x3 matrix
+    - from "pytorch" centered [0, 0] with `[-1,1] x [-1, 1]` normalized coordinates
+    - to "classic" top left corner referential classic image coordinates `[0, h-1] x [0, w-1]`
+
+    https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
+    """
+    scale = torch.tensor([[(w - 1) / 2., 0., 0.], [0., (h - 1) /
+                         2., 0.], [0., 0., 1.]], device=device, dtype=dtype)
+    center_offset = torch.tensor(
+        [[1., 0., 1.], [0., 1., 1.], [0., 0., 1.]], device=device, dtype=dtype)
+    return torch.matmul(scale, center_offset).to(dtype=dtype)
+
+
+def metric_to_normalized(h: int, w: int, dtype=torch.float64, device='cpu'):
+    """Referential change 3x3 matrix
+    - from "classic" top left corner referential classic image coordinates `[0, h-1] x [0, w-1]`
+    - to "pytorch" centered [0, 0] with `[-1,1] x [-1, 1]` normalized coordinates
+    """
+    return torch.linalg.inv(normalized_to_metric(h, w, dtype=dtype, device=device))
+
+
+def transform_metric_to_normalized_torch(transforms_metric: torch.Tensor,
+                                         input_size: tuple,
+                                         output_size: tuple,
+                                         is_affinity: bool = False) -> torch.Tensor:
+    """Transform a tensor of homographies / affinities
+    - from metric (classic image top left corner definition)
+    - to normalized referential (pytorch definition)
+    """
+    if transforms_metric.shape[-2] == 2:  # 2x3 matrix to 3x3 matrix
+        third_row = torch.tensor(
+            [[[0., 0., 1.]]], dtype=transforms_metric.dtype, device=transforms_metric.device)
+        third_row = third_row.repeat(transforms_metric.shape[-3], 1, 1)
+        transforms_metric = torch.cat([transforms_metric, third_row], dim=-2)
+    m2n = metric_to_normalized(
+        input_size[0], input_size[1], device=transforms_metric.device)  # 3x3 matrix
+    n2m = normalized_to_metric(
+        output_size[0], output_size[1], device=transforms_metric.device)  # 3x3 matrix
+    normed_transform = torch.matmul(
+        m2n, torch.matmul(transforms_metric, n2m))  # 3x3 matrix
+    if is_affinity:
+        normed_transform = normed_transform[:2, :]  # return 2x3 matrix
+    return normed_transform


### PR DESCRIPTION
A simple Cuda Kernel to warp torch tensors using an homogrpahy

Cuda version
CPU version fallback (not optimized) Seems like the custom cuda version is much faster that the native torch combination of torch.nn.functional.affine_grid & torch.nn.functional.grid_sample.